### PR TITLE
:bento: Update character names announced for v6.6+

### DIFF
--- a/alembic/versions/8e22df58cff8_add_run_once_field_to_auto_push_config.py
+++ b/alembic/versions/8e22df58cff8_add_run_once_field_to_auto_push_config.py
@@ -9,9 +9,9 @@ Create Date: 2026-01-16 22:08:51.898883
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
-from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.
 revision: str = "8e22df58cff8"

--- a/metadata/name_map/genshin.json
+++ b/metadata/name_map/genshin.json
@@ -689,6 +689,16 @@
             "レイラ"
         ]
     },
+    "Lohen": {
+        "name": [
+            "Lohen",
+            "洛恩"
+        ],
+        "regex": [],
+        "aliases": [
+            "ローエン"
+        ]
+    },
     "Lumine": {
         "name": [
             "Lumine",
@@ -847,13 +857,15 @@
             "ヌヴィレット"
         ]
     },
-    "NicoleReeyn": {
+    "Nicole": {
         "name": [
-            "NicoleReeyn",
-            "尼可莱恩"
+            "Nicole",
+            "尼可"
         ],
         "regex": [],
         "aliases": [
+            "尼可莱恩",
+            "ニコ",
             "ニコ・リヤン",
             "ニコリヤン"
         ]
@@ -915,6 +927,16 @@
         "regex": [],
         "aliases": [
             "ピエロ"
+        ]
+    },
+    "Prune": {
+        "name": [
+            "Prune",
+            "布伦妮"
+        ],
+        "regex": [],
+        "aliases": [
+            "プルーネ"
         ]
     },
     "Qiqi": {

--- a/tests/test_name_map.py
+++ b/tests/test_name_map.py
@@ -1,5 +1,4 @@
 import json
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -20,7 +19,7 @@ SAMPLE_DATA = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def name_map(tmp_path: Path) -> NameMap:
     f = tmp_path / "test.json"
     f.write_text(json.dumps(SAMPLE_DATA), encoding="utf-8")


### PR DESCRIPTION
See the official hoyolab posts:
- https://www.hoyolab.com/article/44627867
- https://www.hoyolab.com/article/44642708
- https://www.hoyolab.com/article/44646041

As per usual, the `getPostFull` curl like the one below has the name (modify `x-rpc-language` for different languages):

```
curl 'https://bbs-api-os.hoyolab.com/community/post/wapi/getPostFull?post_id=44646041&read=1&scene=1' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'accept-language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7' \
  -H 'origin: https://www.hoyolab.com' \
  -H 'priority: u=1, i' \
  -H 'referer: https://www.hoyolab.com/' \
  -H 'sec-ch-ua: "Not(A:Brand";v="8", "Chromium";v="144", "Microsoft Edge";v="144"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Windows"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-site' \
  -H 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36 Edg/144.0.0.0' \
  -H 'x-rpc-app_version: 4.11.0' \
  -H 'x-rpc-client_type: 4' \
  -H 'x-rpc-device_id: 35667467-8319-4c7b-afad-51018c8d958a' \
  -H 'x-rpc-hour: 12' \
  -H 'x-rpc-lrsag;' \
  -H 'x-rpc-page_info: {"pageName":"","pageType":"","pageId":"","pageArrangement":"","gameId":""}' \
  -H 'x-rpc-page_name;' \
  -H 'x-rpc-preference_ids: 2,6,8' \
  -H 'x-rpc-show-translated: false' \
  -H 'x-rpc-source_info: {"sourceName":"","sourceType":"","sourceId":"","sourceArrangement":"","sourceGameId":""}' \
  -H 'x-rpc-sys_version: Windows NT 10.0' \
  -H 'x-rpc-timezone: America/Chicago' \
  -H 'x-rpc-language: ja-jp' \
  -H 'x-rpc-weekday: 6'
```